### PR TITLE
chore: support for Bucklescript version 8

### DIFF
--- a/bs-emotion/bsconfig.json
+++ b/bs-emotion/bsconfig.json
@@ -4,7 +4,7 @@
   "bs-dependencies": [
     "@minima.app/re-css"
   ],
-  "reason": { "react-jsx": 2 },
+  "reason": { "react-jsx": 3 },
   "refmt": 3,
   "bsc-flags": ["-open Belt"],
   "package-specs": {


### PR DESCRIPTION
Since `bucklescript` release version https://github.com/BuckleScript/bucklescript/releases/tag/8.0.1 , `react-jsx` version 2 it's unsupported and got error like this when your start `compiling` with `bs-platform`. 

```bash
 𝝀 ~/w0/project yarn bsb   
yarn run v1.21.1
$ bsb -make-world -w -ws _
[56/56] Building src/legacy/ReactDOMRe.cmj
[5/5] Building src/Css.cmj
File "bsconfig.json", line 7:
Error: Unsupported jsx version 2
For more details, please checkout the schema http://bucklescript.github.io/bucklescript/docson/#build-schema.json
```

Simply solve this problem just change `react-jsx` field in `bsconfig.json` in `node_modules/@ahrefs/bs-emotion/bsconfig.json`

Thanks